### PR TITLE
Added Audio Alert

### DIFF
--- a/vmPing/Classes/ApplicationOptions.cs
+++ b/vmPing/Classes/ApplicationOptions.cs
@@ -19,6 +19,8 @@ namespace vmPing.Classes
         public static int AlertThreshold { get; set; } = 2;
         public static bool IsEmailAlertEnabled { get; set; } = false;
         public static bool IsEmailAuthenticationRequired { get; set; } = false;
+        public static bool IsAudioAlertEnabled { get; set; } = false;
+        public static string AudioFilePath { get; set; }
         public static string EmailServer { get; set; }
         public static string EmailUser { get; set; }
         public static string EmailPassword { get; set; }

--- a/vmPing/Classes/Configuration.cs
+++ b/vmPing/Classes/Configuration.cs
@@ -325,6 +325,14 @@ namespace vmPing.Classes
                 value: ApplicationOptions.EmailFromAddress != null ? ApplicationOptions.EmailFromAddress.ToString() : string.Empty));
             configuration.AppendChild(GenerateOptionNode(
                 xmlDocument: xd,
+                name: "IsAudioAlertEnabled",
+                value: ApplicationOptions.IsAudioAlertEnabled.ToString()));
+            configuration.AppendChild(GenerateOptionNode(
+                xmlDocument: xd,
+                name: "AudioFilePath",
+                value: ApplicationOptions.AudioFilePath != null ? ApplicationOptions.AudioFilePath.ToString() : string.Empty));
+            configuration.AppendChild(GenerateOptionNode(
+                xmlDocument: xd,
                 name: "IsLogOutputEnabled",
                 value: ApplicationOptions.IsLogOutputEnabled.ToString()));
             configuration.AppendChild(GenerateOptionNode(
@@ -552,6 +560,14 @@ namespace vmPing.Classes
             if (options.TryGetValue("EmailFromAddress", out optionValue))
             {
                 ApplicationOptions.EmailFromAddress = optionValue;
+            }
+            if (options.TryGetValue("IsAudioAlertEnabled", out optionValue))
+            {
+                ApplicationOptions.IsAudioAlertEnabled = bool.Parse(optionValue);
+            }
+            if (options.TryGetValue("AudioFilePath", out optionValue))
+            {
+                ApplicationOptions.AudioFilePath = optionValue;
             }
             if (options.TryGetValue("IsLogOutputEnabled", out optionValue))
             {

--- a/vmPing/Classes/Probe-Util.cs
+++ b/vmPing/Classes/Probe-Util.cs
@@ -6,6 +6,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
 using vmPing.Views;
+using System.Media;
 
 namespace vmPing.Classes
 {
@@ -199,6 +200,12 @@ namespace vmPing.Classes
 
             if (ApplicationOptions.IsLogStatusChangesEnabled && ApplicationOptions.LogStatusChangesPath.Length > 0)
                 WriteToStatusChangesLog(status);
+
+            if ((status.Status == ProbeStatus.Down) && (ApplicationOptions.IsAudioAlertEnabled))
+            {
+                SoundPlayer player = new SoundPlayer(ApplicationOptions.AudioFilePath);
+                player.Play();
+            }
         }
     }
 }

--- a/vmPing/Classes/Probe-Util.cs
+++ b/vmPing/Classes/Probe-Util.cs
@@ -5,8 +5,10 @@ using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
-using vmPing.Views;
 using System.Media;
+
+using vmPing.Views;
+
 
 namespace vmPing.Classes
 {

--- a/vmPing/Views/OptionsWindow.xaml
+++ b/vmPing/Views/OptionsWindow.xaml
@@ -13,6 +13,20 @@
         Loaded="Window_Loaded">
 
     <Window.Resources>
+        <Style TargetType="StackPanel" x:Key="AudioOptionsStackPanel">
+            <Setter Property="Margin" Value="0,4,20,3" />
+            <Setter Property="Orientation" Value="Horizontal" />
+            <Setter Property="HorizontalAlignment" Value="Left" />
+            <Setter Property="DockPanel.Dock" Value="Top" />
+        </Style>
+
+        <Style TargetType="TextBlock" x:Key="AudioOptionsTextBlock">
+            <Setter Property="Margin" Value="0,0,12,0" />
+            <Setter Property="Foreground" Value="#555" />
+            <Setter Property="VerticalAlignment" Value="Center" />
+            <Setter Property="HorizontalAlignment" Value="Right" />
+        </Style>
+        
         <Style TargetType="StackPanel" x:Key="EmailOptionsStackPanel">
             <Setter Property="Margin" Value="0,4,20,3" />
             <Setter Property="Orientation" Value="Horizontal" />
@@ -117,7 +131,6 @@
                     </StackPanel>
                 </Grid>
             </TabItem>
-
 
             <!-- TAB: Advanced -->
             <TabItem Header="Advanced" Name="AdvancedTab">
@@ -251,7 +264,6 @@
                 </DockPanel>
             </TabItem>
 
-
             <!-- TAB: Email Alerts -->
             <TabItem Header="Email Alerts" Name="EmailAlertsTab">
                 <DockPanel>
@@ -372,8 +384,60 @@
                 </DockPanel>
             </TabItem>
 
+            <!-- TAB: Audio Alerts -->
+            <TabItem Header="Audio Alerts" Name="AudioAlertTab">
+                <DockPanel>
 
-            <!-- TAB: Email Alerts -->
+                    <!-- Header -->
+                    <TextBlock DockPanel.Dock="Top"
+                               Text="Audio Alerts"
+                               Style="{StaticResource OptionHeaderTextStyle}" />
+
+                    <CheckBox DockPanel.Dock="Top"
+                              Name="IsAudioAlertEnabled"
+                              Content="Enable audio alerts"
+                              Click="IsAudioAlertEnabled_Click"
+                              IsChecked="True"
+                              Margin="20,15,0,15"
+                              FontSize="14" />
+
+                    <DockPanel LastChildFill="False"
+                               DockPanel.Dock="Top"
+                               Margin="20,0,20,0"
+                               Visibility="{Binding IsChecked, ElementName=IsAudioAlertEnabled, Converter={StaticResource BooleanToVisibilityConverter}}">
+
+                        <!-- Separator -->
+                        <Separator DockPanel.Dock="Top" Height="1" Background="#ccc" />
+
+                        <TextBlock DockPanel.Dock="Top"
+                                   Text="Audio File Information"
+                                   Style="{StaticResource OptionSubHeaderTextStyle}" />
+
+                        <!-- Audio File -->
+                        <Grid DockPanel.Dock="Top"
+                          Margin="41,10,20,0"
+                          VerticalAlignment="Top"
+                          Visibility="{Binding IsChecked, ElementName=IsLogStatusChangesEnabled, Converter={StaticResource BooleanToVisibilityConverter}}">
+                            <StackPanel>
+                                <TextBlock Style="{StaticResource EmailOptionsTextBlock}"
+                                       HorizontalAlignment="Left"
+                                       Text="Audio file path" />
+                                <TextBox Style="{StaticResource TextBoxStyle}"
+                                     Margin="0,5,0,8"
+                                     Name="AudioFilePath" />
+                                <Button Style="{StaticResource ButtonSecondaryStyle}"
+                                    Click="AudioFilePath_Click"
+                                    Width="70"
+                                    Content="Browse"
+                                    HorizontalAlignment="Right"/>
+                            </StackPanel>
+                        </Grid>
+
+                    </DockPanel>
+                </DockPanel>
+            </TabItem>
+
+            <!-- TAB: Log Output -->
             <TabItem Header="Log Output" Name="LogOutputTab">
                 <DockPanel>
 

--- a/vmPing/Views/OptionsWindow.xaml
+++ b/vmPing/Views/OptionsWindow.xaml
@@ -13,28 +13,14 @@
         Loaded="Window_Loaded">
 
     <Window.Resources>
-        <Style TargetType="StackPanel" x:Key="AudioOptionsStackPanel">
+        <Style TargetType="StackPanel" x:Key="OptionsStackPanel">
             <Setter Property="Margin" Value="0,4,20,3" />
             <Setter Property="Orientation" Value="Horizontal" />
             <Setter Property="HorizontalAlignment" Value="Left" />
             <Setter Property="DockPanel.Dock" Value="Top" />
         </Style>
 
-        <Style TargetType="TextBlock" x:Key="AudioOptionsTextBlock">
-            <Setter Property="Margin" Value="0,0,12,0" />
-            <Setter Property="Foreground" Value="#555" />
-            <Setter Property="VerticalAlignment" Value="Center" />
-            <Setter Property="HorizontalAlignment" Value="Right" />
-        </Style>
-        
-        <Style TargetType="StackPanel" x:Key="EmailOptionsStackPanel">
-            <Setter Property="Margin" Value="0,4,20,3" />
-            <Setter Property="Orientation" Value="Horizontal" />
-            <Setter Property="HorizontalAlignment" Value="Left" />
-            <Setter Property="DockPanel.Dock" Value="Top" />
-        </Style>
-
-        <Style TargetType="TextBlock" x:Key="EmailOptionsTextBlock">
+        <Style TargetType="TextBlock" x:Key="OptionsTextBlock">
             <Setter Property="Margin" Value="0,0,12,0" />
             <Setter Property="Foreground" Value="#555" />
             <Setter Property="VerticalAlignment" Value="Center" />
@@ -294,9 +280,9 @@
                                    Style="{StaticResource OptionSubHeaderTextStyle}" />
 
                         <!-- SMTP Server-->
-                        <StackPanel Style="{StaticResource EmailOptionsStackPanel}">
+                        <StackPanel Style="{StaticResource OptionsStackPanel}">
                             <Grid Width="120">
-                                <TextBlock Style="{StaticResource EmailOptionsTextBlock}"
+                                <TextBlock Style="{StaticResource OptionsTextBlock}"
                                            Text="SMTP server" />
                             </Grid>
                             <TextBox Style="{StaticResource TextBoxStyle}"
@@ -305,9 +291,9 @@
                         </StackPanel>
 
                         <!-- Smtp Port -->
-                        <StackPanel Style="{StaticResource EmailOptionsStackPanel}">
+                        <StackPanel Style="{StaticResource OptionsStackPanel}">
                             <Grid Width="120">
-                                <TextBlock Style="{StaticResource EmailOptionsTextBlock}"
+                                <TextBlock Style="{StaticResource OptionsTextBlock}"
                                            Text="Port" />
                             </Grid>
                             <TextBox Style="{StaticResource TextBoxStyle}"
@@ -329,9 +315,9 @@
                         <StackPanel DockPanel.Dock="Top"
                                     Visibility="{Binding IsChecked, ElementName=IsSmtpAuthenticationRequired, Converter={StaticResource BooleanToVisibilityConverter}}">
                             <!-- Smtp User -->
-                            <StackPanel Style="{StaticResource EmailOptionsStackPanel}">
+                            <StackPanel Style="{StaticResource OptionsStackPanel}">
                                 <Grid Width="120">
-                                    <TextBlock Style="{StaticResource EmailOptionsTextBlock}"
+                                    <TextBlock Style="{StaticResource OptionsTextBlock}"
                                                Text="Username" />
                                 </Grid>
                                 <TextBox Style="{StaticResource TextBoxStyle}"
@@ -340,9 +326,9 @@
                             </StackPanel>
 
                             <!-- Smtp Password -->
-                            <StackPanel Style="{StaticResource EmailOptionsStackPanel}">
+                            <StackPanel Style="{StaticResource OptionsStackPanel}">
                                 <Grid Width="120">
-                                    <TextBlock Style="{StaticResource EmailOptionsTextBlock}"
+                                    <TextBlock Style="{StaticResource OptionsTextBlock}"
                                                Text="Password" />
                                 </Grid>
                                 <PasswordBox Style="{StaticResource PasswordBoxStyle}"
@@ -359,9 +345,9 @@
                                    Style="{StaticResource OptionSubHeaderTextStyle}" />
 
                         <!-- Recipient Address-->
-                        <StackPanel Style="{StaticResource EmailOptionsStackPanel}">
+                        <StackPanel Style="{StaticResource OptionsStackPanel}">
                             <Grid Width="120">
-                                <TextBlock Style="{StaticResource EmailOptionsTextBlock}"
+                                <TextBlock Style="{StaticResource OptionsTextBlock}"
                                            Text="Recipient address" />
                             </Grid>
                             <TextBox Style="{StaticResource TextBoxStyle}"
@@ -371,9 +357,9 @@
                         </StackPanel>
 
                         <!-- From Address-->
-                        <StackPanel Style="{StaticResource EmailOptionsStackPanel}">
+                        <StackPanel Style="{StaticResource OptionsStackPanel}">
                             <Grid Width="120">
-                                <TextBlock Style="{StaticResource EmailOptionsTextBlock}"
+                                <TextBlock Style="{StaticResource OptionsTextBlock}"
                                            Text="From address" />
                             </Grid>
                             <TextBox Style="{StaticResource TextBoxStyle}"
@@ -419,7 +405,7 @@
                           VerticalAlignment="Top"
                           Visibility="{Binding IsChecked, ElementName=IsLogStatusChangesEnabled, Converter={StaticResource BooleanToVisibilityConverter}}">
                             <StackPanel>
-                                <TextBlock Style="{StaticResource EmailOptionsTextBlock}"
+                                <TextBlock Style="{StaticResource OptionsTextBlock}"
                                        HorizontalAlignment="Left"
                                        Text="Audio file path" />
                                 <TextBox Style="{StaticResource TextBoxStyle}"
@@ -481,7 +467,7 @@
                           VerticalAlignment="Top"
                           Visibility="{Binding IsChecked, ElementName=IsLogOutputEnabled, Converter={StaticResource BooleanToVisibilityConverter}}">
                         <StackPanel>
-                            <TextBlock Style="{StaticResource EmailOptionsTextBlock}"
+                            <TextBlock Style="{StaticResource OptionsTextBlock}"
                                        HorizontalAlignment="Left"
                                        Text="Log path (base directory)" />
                             <TextBox Style="{StaticResource TextBoxStyle}"
@@ -530,7 +516,7 @@
                           VerticalAlignment="Top"
                           Visibility="{Binding IsChecked, ElementName=IsLogStatusChangesEnabled, Converter={StaticResource BooleanToVisibilityConverter}}">
                         <StackPanel>
-                            <TextBlock Style="{StaticResource EmailOptionsTextBlock}"
+                            <TextBlock Style="{StaticResource OptionsTextBlock}"
                                        HorizontalAlignment="Left"
                                        Text="Log path" />
                             <TextBox Style="{StaticResource TextBoxStyle}"

--- a/vmPing/Views/OptionsWindow.xaml.cs
+++ b/vmPing/Views/OptionsWindow.xaml.cs
@@ -28,7 +28,7 @@ namespace vmPing.Views
             PopulateLayoutOptions();
         }
 
-        private void ShowError(string message, TabItem tabItem, System.Windows.Controls.Control control)
+        private void ShowError(string message, TabItem tabItem, Control control)
         {
             tabItem.Focus();
             var errorWindow = DialogWindow.ErrorWindow(message);

--- a/vmPing/Views/OptionsWindow.xaml.cs
+++ b/vmPing/Views/OptionsWindow.xaml.cs
@@ -22,12 +22,13 @@ namespace vmPing.Views
 
             PopulateGeneralOptions();
             PopulateEmailAlertOptions();
+            PopulateAudioAlertOptions();
             PopulateLogOutputOptions();
             PopulateAdvancedOptions();
             PopulateLayoutOptions();
         }
 
-        private void ShowError(string message, TabItem tabItem, Control control)
+        private void ShowError(string message, TabItem tabItem, System.Windows.Controls.Control control)
         {
             tabItem.Focus();
             var errorWindow = DialogWindow.ErrorWindow(message);
@@ -78,6 +79,11 @@ namespace vmPing.Views
             SmtpPassword.Password = ApplicationOptions.EmailPassword;
             EmailRecipientAddress.Text = ApplicationOptions.EmailRecipient;
             EmailFromAddress.Text = ApplicationOptions.EmailFromAddress;
+        }
+        private void PopulateAudioAlertOptions()
+        {
+            IsAudioAlertEnabled.IsChecked = ApplicationOptions.IsAudioAlertEnabled;
+            AudioFilePath.Text = ApplicationOptions.AudioFilePath;            
         }
 
         private void PopulateLogOutputOptions()
@@ -138,6 +144,9 @@ namespace vmPing.Views
                 return;
 
             if (SaveEmailAlertOptions() == false)
+                return;
+
+            if (SaveAudioAlertOptions() == false)
                 return;
 
             if (SaveLogOutputOptions() == false)
@@ -345,6 +354,36 @@ namespace vmPing.Views
             }
         }
 
+        private bool SaveAudioAlertOptions()
+        {
+            if(IsAudioAlertEnabled.IsChecked == true)
+            {
+                try
+                {
+                    if (Path.GetFileName(AudioFilePath.Text).IndexOfAny(Path.GetInvalidFileNameChars()) >= 0 ||
+                        !Directory.Exists(Path.GetDirectoryName(AudioFilePath.Text)) ||
+                        Path.GetFileName(AudioFilePath.Text).Length < 1)
+                    {
+                        MessageBox.Show(Path.GetFileName(AudioFilePath.Text));
+                        throw new Exception();
+                    }
+                }
+                catch
+                {
+                    ShowError("The specified path does not exist.  Please enter a valid path.", AudioAlertTab, AudioFilePath);
+                    return false;
+                }
+                ApplicationOptions.IsAudioAlertEnabled = true;
+                ApplicationOptions.AudioFilePath = AudioFilePath.Text;
+            }
+            else
+            {
+                ApplicationOptions.IsAudioAlertEnabled = false;
+            }
+
+            return true;
+        }
+
         private bool SaveLogOutputOptions()
         {
             if (IsLogOutputEnabled.IsChecked == true)
@@ -485,6 +524,12 @@ namespace vmPing.Views
                 SmtpUsername.Focus();
         }
 
+        private void IsAudioAlertEnabled_Click(object sender, RoutedEventArgs e)
+        {
+            if (IsEmailAlertsEnabled.IsChecked == true && SmtpServer.Text.Length == 0)
+                AudioFilePath.Focus();
+        }
+
         private void BrowseLogPath_Click(object sender, RoutedEventArgs e)
         {
             var dialog = new System.Windows.Forms.FolderBrowserDialog();
@@ -503,6 +548,18 @@ namespace vmPing.Views
 
             if (result == System.Windows.Forms.DialogResult.OK)
                 LogStatusChangesPath.Text = dialog.SelectedPath + "\\vmping-status.txt";
+        }
+
+        private void AudioFilePath_Click(object sender, RoutedEventArgs e)
+        {
+            System.Console.WriteLine(AudioFilePath.Text);
+            var audiofileDialog = new System.Windows.Forms.OpenFileDialog();
+            audiofileDialog.Title = "Select an audio file";
+            audiofileDialog.RestoreDirectory = true;
+            audiofileDialog.Multiselect = false;
+                          
+            if (audiofileDialog.ShowDialog() == System.Windows.Forms.DialogResult.OK)
+                AudioFilePath.Text = audiofileDialog.FileName;
         }
 
         private void UpdateByteCount()


### PR DESCRIPTION
Ryan,
I appreciate you putting this project out there!  I wanted to add a host down audio alert so I can run this in the background and not have to watch my screen or emails during the boring parts of a migration.

If a host goes down it will play the audio file once. No audio for host recovery, but I'd be happy to add the option. 

Figured I'd share it back with you if you want to add it.  If not no big deal.  Apologies if I did something goofy. I'm not super duper git savvy, or even a little git savvy lol. 

LMK if you have questions.


![vmPing_Ul3qMPxfkl](https://user-images.githubusercontent.com/24415613/58906399-d02ac580-86d9-11e9-8d70-9c5b3a3f2c31.png)
![explorer_xD0EUCbbMA](https://user-images.githubusercontent.com/24415613/58906403-d1f48900-86d9-11e9-8830-042d376ac2f2.png)
![notepad++_ZYNKAO7enS](https://user-images.githubusercontent.com/24415613/58906410-d4ef7980-86d9-11e9-98e7-26c1b04e900d.png)
