### PR TITLE
Trim spaces from hostnames and parse host file with spaces / comments

### DIFF
--- a/vmPing/Classes/CommandLine.cs
+++ b/vmPing/Classes/CommandLine.cs
@@ -100,7 +100,22 @@ namespace vmPing.Classes
         {
             try
             {
-                return new List<string>(File.ReadAllLines(path));
+                
+                var linesInFile = new List<string>(File.ReadAllLines(path));
+                var hostsInFile = new List<string>();
+
+                foreach (var line in linesInFile)
+                {
+                    if (line == String.Empty)
+                        continue;
+
+                    if (!Char.IsLetterOrDigit(line[0]))
+                        continue;
+                    
+                    hostsInFile.Add(line.Trim());
+                }
+
+                return hostsInFile;
             }
             catch
             {

--- a/vmPing/Classes/Probe.cs
+++ b/vmPing/Classes/Probe.cs
@@ -83,7 +83,7 @@ namespace vmPing.Classes
             {
                 if (value != hostname)
                 {
-                    hostname = value;
+                    hostname = value.Trim();
                     NotifyPropertyChanged("Hostname");
                 }
             }


### PR DESCRIPTION
Made two changes:

* Trim spaces from hostname field.
* Modified ReadHostsFromFile() so it will ignore empty lines and lines that start with anything that isn't a letter or number. Allows for comments and a more human readable file to used. 

Example hosts file:

```
# Domain Controllers
DC01
DC02

 
 
# file servers
FS01
FS02
```
