### PR TITLE
Added a Type "Comment" that has to start with "#"

### DIFF
--- a/vmPing/Classes/Probe-Util.cs
+++ b/vmPing/Classes/Probe-Util.cs
@@ -24,7 +24,9 @@ namespace vmPing.Classes
             {
                 // Starting probe.
                 CancelSource = new CancellationTokenSource();
-                if (Hostname.StartsWith("D/"))
+                if (Hostname.StartsWith("#"))
+                        Type = ProbeType.Comment;
+                else if (Hostname.StartsWith("D/"))
                 {
                     Type = ProbeType.Dns;
                     Hostname = Hostname.Substring(2);

--- a/vmPing/Classes/Probe.cs
+++ b/vmPing/Classes/Probe.cs
@@ -28,7 +28,8 @@ namespace vmPing.Classes
     {
         Dns,
         Ping,
-        Traceroute
+        Traceroute,
+        Comment
     }
 
 

--- a/vmPing/Properties/Strings.resx
+++ b/vmPing/Properties/Strings.resx
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="Button_Ping" xml:space="preserve">
-    <value>Ping</value>
+    <value>Start</value>
   </data>
   <data name="Button_Stop" xml:space="preserve">
     <value>Stop</value>

--- a/vmPing/Properties/Strings.resx
+++ b/vmPing/Properties/Strings.resx
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="Button_Ping" xml:space="preserve">
-    <value>Start</value>
+    <value>Ping</value>
   </data>
   <data name="Button_Stop" xml:space="preserve">
     <value>Stop</value>

--- a/vmPing/Views/MainWindow.xaml
+++ b/vmPing/Views/MainWindow.xaml
@@ -627,8 +627,8 @@
                                          Template="{StaticResource TextBoxControlTemplate}"
                                          Loaded="Hostname_Loaded"
                                          TextChanged="Hostname_TextChanged"
-                                         KeyDown="Hostname_KeyDown"
-                           ToolTip="Examples:&#10;Ping: 'github.com'  |  Trace route:  'T/google.de'  |  DNS Resolution:  'D/google.com'&#10;TCP-Test: 'github.com:80'  |  Comments:  '#8.8.8.8 does nothing'"/>
+                                         KeyDown="Hostname_KeyDown"/>
+
                                 <!-- Ping button -->
                                 <Button Click="ProbeStartStop_Click"
                                         Grid.Column="2"

--- a/vmPing/Views/MainWindow.xaml
+++ b/vmPing/Views/MainWindow.xaml
@@ -627,8 +627,8 @@
                                          Template="{StaticResource TextBoxControlTemplate}"
                                          Loaded="Hostname_Loaded"
                                          TextChanged="Hostname_TextChanged"
-                                         KeyDown="Hostname_KeyDown"/>
-
+                                         KeyDown="Hostname_KeyDown"
+                           ToolTip="Examples:&#10;Ping: 'github.com'  |  Trace route:  'T/google.de'  |  DNS Resolution:  'D/google.com'&#10;TCP-Test: 'github.com:80'  |  Comments:  '#8.8.8.8 does nothing'"/>
                                 <!-- Ping button -->
                                 <Button Click="ProbeStartStop_Click"
                                         Grid.Column="2"


### PR DESCRIPTION
made a solution for issue #64
Just write # as first char of your ip and it wont do anything. Use it as a placeholder or if you know about an error, restart vmping often and do not want to start this to ping automatically

Only these two files should be changed, the others were accidentially commited to that branch and the pull request. So just update:
vmPing/Classes/Probe.cs
vmPing/Classes/Probe-Util.cs